### PR TITLE
fix: rollback rmcp to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rmcp"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
+checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
 dependencies = [
  "async-trait",
  "base64",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
+checksum = "e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.40", default-features = false, features = ["std", "help", "error-context", "usage", "suggestions", "derive", "string"] }
-rmcp = { version = "0.13.0", default-features = false, features = ["base64", "server", "macros", "transport-io"] }
+rmcp = { version = "0.12.0", default-features = false, features = ["base64", "server", "macros", "transport-io"] }
 schemars = "1.1.0"
 serde = { version ="1.0.219", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION
rmcp 0.13.0 doesn't work with VS Code

```
2026-01-19 17:48:24.591 [info] Starting server rust-mcp-server
2026-01-19 17:48:24.591 [info] Connection state: Starting
2026-01-19 17:48:24.591 [info] Starting server from LocalProcess extension host
2026-01-19 17:48:24.709 [info] Connection state: Starting
2026-01-19 17:48:24.709 [info] Connection state: Running
2026-01-19 17:48:24.722 [warning] [server stderr] Error: Failed to start server
2026-01-19 17:48:24.722 [warning] [server stderr] 
2026-01-19 17:48:24.722 [warning] [server stderr] Caused by:
2026-01-19 17:48:24.722 [warning] [server stderr]     expect initialized request, but received: Some(Request(JsonRpcRequest { jsonrpc: JsonRpcVersion2_0, id: Number(1), request: CustomRequest(CustomRequest { method: "initialize", params: Some(Object {"capabilities": Object {"elicitation": Object {"form": Object {}, "url": Object {}}, "roots": Object {"listChanged": Bool(true)}, "sampling": Object {}, "tasks": Object {"cancel": Object {}, "list": Object {}, "requests": Object {"elicitation": Object {"create": Object {}}, "sampling": Object {"createMessage": Object {}}}}}, "clientInfo": Object {"name": String("Visual Studio Code"), "version": String("1.108.0")}, "protocolVersion": String("2025-11-25")}), extensions: Extensions }) }))
2026-01-19 17:48:24.732 [info] Connection state: Error Process exited with code 1
```

https://github.com/modelcontextprotocol/rust-sdk/issues/613