### PR TITLE
fix: use manifest path as cwd

### DIFF
--- a/crates/rust-mcp-server/src/command.rs
+++ b/crates/rust-mcp-server/src/command.rs
@@ -4,7 +4,6 @@ use rmcp::{
 };
 
 use crate::meta::Meta;
-use crate::workspace::apply_workspace_root;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CommandLine(pub String);
@@ -169,8 +168,11 @@ impl From<Output> for CallToolResult {
 pub(crate) fn execute_command(
     mut cmd: std::process::Command,
     tool_name: &str,
+    cwd: Option<&std::path::Path>,
 ) -> Result<Output, ErrorData> {
-    apply_workspace_root(&mut cmd);
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
 
     let cmd_line = format!(
         "{} {}",

--- a/crates/rust-mcp-server/src/globals.rs
+++ b/crates/rust-mcp-server/src/globals.rs
@@ -1,21 +1,46 @@
-use std::{path::PathBuf, sync::OnceLock};
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
-static WORKSPACE_ROOT: OnceLock<PathBuf> = OnceLock::new();
+/// The workspace root together with how it was determined.
+#[derive(Debug)]
+pub(crate) enum WorkspaceRoot {
+    /// Set explicitly (e.g. via the CLI). Takes precedence over any per-command
+    /// manifest directory.
+    Explicit(PathBuf),
+    /// Auto-detected from the client's roots.
+    Detected(PathBuf),
+}
+
+impl WorkspaceRoot {
+    pub(crate) fn path(&self) -> &Path {
+        match self {
+            Self::Explicit(path) | Self::Detected(path) => path,
+        }
+    }
+}
+
+static WORKSPACE_ROOT: OnceLock<WorkspaceRoot> = OnceLock::new();
 static DEFAULT_REGISTRY: OnceLock<String> = OnceLock::new();
 
+/// Sets the workspace root explicitly (e.g. from the CLI). An explicitly set
+/// root takes precedence over any per-command manifest directory.
 pub fn set_workspace_root(root: impl Into<PathBuf>) {
     WORKSPACE_ROOT
-        .set(root.into())
+        .set(WorkspaceRoot::Explicit(root.into()))
         .expect("Workspace root can only be set once");
 }
 
-/// Attempts to set the workspace root. Returns `true` if set successfully,
-/// `false` if it was already set (e.g. via CLI argument).
+/// Attempts to set the workspace root via auto-detection. Returns `true` if set
+/// successfully, `false` if it was already set (e.g. via CLI argument).
 pub fn try_set_workspace_root(root: impl Into<PathBuf>) -> bool {
-    WORKSPACE_ROOT.set(root.into()).is_ok()
+    WORKSPACE_ROOT
+        .set(WorkspaceRoot::Detected(root.into()))
+        .is_ok()
 }
 
-pub fn get_workspace_root() -> Option<&'static PathBuf> {
+pub fn get_workspace_root() -> Option<&'static WorkspaceRoot> {
     WORKSPACE_ROOT.get()
 }
 

--- a/crates/rust-mcp-server/src/main.rs
+++ b/crates/rust-mcp-server/src/main.rs
@@ -22,6 +22,7 @@ use tool::Tool;
 use tracing_appender::rolling;
 use tracing_subscriber::{EnvFilter, fmt};
 use version::AppVersion;
+use workspace::command_cwd;
 
 const RMCP_VERSION: &str = env!("RMCP_VERSION");
 

--- a/crates/rust-mcp-server/src/tools/cargo/add_remove.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/add_remove.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Response, Tool, execute_command,
+    Response, Tool, command_cwd, execute_command,
     serde_utils::{
         PackageWithVersion, deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -233,7 +233,8 @@ impl Tool for CargoAddRmcpTool {
     type RequestArgs = CargoAddRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 
@@ -356,7 +357,8 @@ impl Tool for CargoRemoveRmcpTool {
     type RequestArgs = CargoRemoveRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 

--- a/crates/rust-mcp-server/src/tools/cargo/build.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Response, Tool, execute_command,
+    Response, Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -285,8 +285,9 @@ impl Tool for CargoBuildRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
+        let cwd = command_cwd(request.manifest_path.as_deref());
         let start_time = std::time::Instant::now();
-        let output = execute_command(cmd, Self::NAME)?;
+        let output = execute_command(cmd, Self::NAME, cwd)?;
         let duration = start_time.elapsed();
 
         let mut response: Response = output.into();

--- a/crates/rust-mcp-server/src/tools/cargo/check.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/check.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -283,6 +283,7 @@ impl Tool for CargoCheckRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        execute_command(cmd, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(cmd, Self::NAME, cwd).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo/clippy.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/clippy.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 use crate::{
     Tool,
     command::execute_command,
+    command_cwd,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -287,7 +288,8 @@ impl Tool for CargoClippyRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        let output = execute_command(cmd, Self::NAME)?;
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        let output = execute_command(cmd, Self::NAME, cwd)?;
 
         let add_fix_recommendation = !request.fix.unwrap_or(false) && output.stderr.is_some();
         let add_fmt_recommendation = request.fix.unwrap_or(false);

--- a/crates/rust-mcp-server/src/tools/cargo/doc.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/doc.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use rmcp::{ErrorData, model::ContentBlock};
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -286,7 +286,7 @@ impl CargoDocRequest {
 
         // Get the absolute path using workspace root
         let absolute_doc_dir = if let Some(workspace_root) = get_workspace_root() {
-            workspace_root.join(&doc_dir)
+            workspace_root.path().join(&doc_dir)
         } else {
             Path::new(&doc_dir).to_path_buf()
         };
@@ -348,8 +348,9 @@ impl Tool for CargoDocRmcpTool {
         use rmcp::model::{Annotations, Role, TextContent};
 
         let cmd = request.build_cmd()?;
+        let cwd = command_cwd(request.manifest_path.as_deref());
         let start_time = std::time::Instant::now();
-        let output = execute_command(cmd, Self::NAME)?;
+        let output = execute_command(cmd, Self::NAME, cwd)?;
         let duration = start_time.elapsed();
 
         if !output.success() {

--- a/crates/rust-mcp-server/src/tools/cargo/info.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/info.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         PackageWithVersion, deserialize_string, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -89,7 +89,7 @@ impl Tool for CargoInfoRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        execute_command(cmd, Self::NAME).map(Into::into)
+        execute_command(cmd, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 #[cfg(test)]

--- a/crates/rust-mcp-server/src/tools/cargo/metadata.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/metadata.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -134,7 +134,8 @@ impl Tool for CargoMetadataRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        let mut response: crate::Response = execute_command(cmd, Self::NAME)?.into();
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        let mut response: crate::Response = execute_command(cmd, Self::NAME, cwd)?.into();
 
         if !request.no_deps.unwrap_or(false) {
             response.add_recommendation(

--- a/crates/rust-mcp-server/src/tools/cargo/mod.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/mod.rs
@@ -29,7 +29,7 @@ pub use workspace_info::CargoWorkspaceInfoRmcpTool;
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -110,7 +110,8 @@ impl Tool for CargoGenerateLockfileRmcpTool {
     type RequestArgs = CargoGenerateLockfileRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 
@@ -248,7 +249,8 @@ impl Tool for CargoCleanRmcpTool {
     type RequestArgs = CargoCleanRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 
@@ -389,7 +391,8 @@ impl Tool for CargoFmtRmcpTool {
     type RequestArgs = CargoFmtRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        let output = execute_command(request.build_cmd()?, Self::NAME)?;
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        let output = execute_command(request.build_cmd()?, Self::NAME, cwd)?;
         let failed = !output.success();
         let mut response: crate::Response = output.into();
 
@@ -515,7 +518,7 @@ impl Tool for CargoNewRmcpTool {
     type RequestArgs = CargoNewRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 
@@ -539,7 +542,7 @@ impl Tool for CargoListRmcpTool {
     type RequestArgs = CargoListRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 

--- a/crates/rust-mcp-server/src/tools/cargo/package.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/package.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -265,6 +265,7 @@ impl Tool for CargoPackageRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        execute_command(cmd, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(cmd, Self::NAME, cwd).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo/search.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/search.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{deserialize_string, output_verbosity_to_cli_flags},
     tools::Registry,
 };
@@ -52,6 +52,6 @@ impl Tool for CargoSearchRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        execute_command(cmd, Self::NAME).map(Into::into)
+        execute_command(cmd, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo/test.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/test.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -316,7 +316,8 @@ impl Tool for CargoTestRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        execute_command(cmd, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(cmd, Self::NAME, cwd).map(Into::into)
     }
 }
 #[cfg(test)]

--- a/crates/rust-mcp-server/src/tools/cargo/tree.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/tree.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     response::Response,
     serde_utils::{deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags},
 };
@@ -195,7 +195,8 @@ impl Tool for CargoTreeRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        let output = execute_command(cmd, Self::NAME)?;
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        let output = execute_command(cmd, Self::NAME, cwd)?;
 
         let stdout_len = if output.success()
             && let Some(stdout) = &output.stdout

--- a/crates/rust-mcp-server/src/tools/cargo/update.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/update.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{
         deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags,
         output_verbosity_to_cli_flags,
@@ -162,6 +162,7 @@ impl Tool for CargoUpdateRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        execute_command(cmd, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(cmd, Self::NAME, cwd).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo/workspace_info.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/workspace_info.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::process::Command;
 
-use crate::{Tool, command::execute_command, serde_utils::deserialize_string};
+use crate::{Tool, command::execute_command, command_cwd, serde_utils::deserialize_string};
 use rmcp::{
     ErrorData,
     model::{Annotations, ContentBlock, Role, TextContent},
@@ -53,7 +53,8 @@ impl Tool for CargoWorkspaceInfoRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         let cmd = request.build_cmd()?;
-        let mut output = execute_command(cmd, Self::NAME)?;
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        let mut output = execute_command(cmd, Self::NAME, cwd)?;
 
         if !output.success() {
             return Ok(output.into());

--- a/crates/rust-mcp-server/src/tools/cargo_deny.rs
+++ b/crates/rust-mcp-server/src/tools/cargo_deny.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags},
 };
 use rmcp::ErrorData;
@@ -241,7 +241,8 @@ impl Tool for CargoDenyCheckRmcpTool {
     type RequestArgs = CargoDenyCheckRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 
@@ -274,7 +275,7 @@ impl Tool for CargoDenyInitRmcpTool {
     type RequestArgs = CargoDenyInitRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 
@@ -331,7 +332,7 @@ impl Tool for CargoDenyListRmcpTool {
     type RequestArgs = CargoDenyListRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 
@@ -357,6 +358,6 @@ impl Tool for CargoDenyInstallRmcpTool {
     type RequestArgs = CargoDenyInstallRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo_expand.rs
+++ b/crates/rust-mcp-server/src/tools/cargo_expand.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use rmcp::ErrorData;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{deserialize_string, deserialize_string_vec, locking_mode_to_cli_flags},
 };
 
@@ -197,6 +197,7 @@ impl Tool for CargoExpandRmcpTool {
     type RequestArgs = CargoExpandRequest;
 
     fn call_rmcp_tool(&self, req: Self::RequestArgs) -> Result<crate::Response, rmcp::ErrorData> {
-        execute_command(req.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(req.manifest_path.as_deref());
+        execute_command(req.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo_hack.rs
+++ b/crates/rust-mcp-server/src/tools/cargo_hack.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{deserialize_string, deserialize_string_vec, output_verbosity_to_cli_flags},
 };
 use rmcp::ErrorData;
@@ -338,7 +338,8 @@ impl Tool for CargoHackRmcpTool {
     type RequestArgs = CargoHackRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 
@@ -364,6 +365,6 @@ impl Tool for CargoHackInstallRmcpTool {
     type RequestArgs = CargoHackInstallRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/cargo_insta.rs
+++ b/crates/rust-mcp-server/src/tools/cargo_insta.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use rmcp::ErrorData;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{deserialize_string, deserialize_string_vec, output_verbosity_to_cli_flags},
 };
 
@@ -162,7 +162,8 @@ impl Tool for CargoInstaUpdateSnapshotsRmcpTool {
     type RequestArgs = CargoInstaUpdateSnapshotsRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        execute_command(request.build_cmd()?, Self::NAME, cwd).map(Into::into)
     }
 }
 

--- a/crates/rust-mcp-server/src/tools/cargo_machete.rs
+++ b/crates/rust-mcp-server/src/tools/cargo_machete.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use crate::{Tool, execute_command, serde_utils::deserialize_string_vec};
+use crate::{Tool, command_cwd, execute_command, serde_utils::deserialize_string_vec};
 use rmcp::ErrorData;
 
 #[derive(Debug, ::serde::Deserialize, schemars::JsonSchema)]
@@ -67,7 +67,7 @@ impl Tool for CargoMacheteRmcpTool {
     type RequestArgs = CargoMacheteRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 
@@ -92,6 +92,6 @@ impl Tool for CargoMacheteInstallRmcpTool {
     type RequestArgs = CargoMacheteInstallRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/rustc.rs
+++ b/crates/rust-mcp-server/src/tools/rustc.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use crate::{Tool, execute_command, serde_utils::deserialize_string};
+use crate::{Tool, command_cwd, execute_command, serde_utils::deserialize_string};
 use rmcp::ErrorData;
 
 #[derive(Debug, ::serde::Deserialize, ::schemars::JsonSchema)]
@@ -37,6 +37,6 @@ impl Tool for RustcExplainRmcpTool {
     type RequestArgs = RustcExplainRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/tools/rustup.rs
+++ b/crates/rust-mcp-server/src/tools/rustup.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use crate::{
-    Tool, execute_command,
+    Tool, command_cwd, execute_command,
     serde_utils::{deserialize_string, deserialize_string_vec},
 };
 use rmcp::ErrorData;
@@ -35,7 +35,7 @@ impl Tool for RustupShowRmcpTool {
     type RequestArgs = RustupShowRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 
@@ -123,7 +123,7 @@ impl Tool for RustupToolchainAddRmcpTool {
     type RequestArgs = RustupToolchainAddRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }
 
@@ -180,6 +180,6 @@ impl Tool for RustupUpdateRmcpTool {
     type RequestArgs = RustupUpdateRequest;
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        execute_command(request.build_cmd()?, Self::NAME).map(Into::into)
+        execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
     }
 }

--- a/crates/rust-mcp-server/src/workspace.rs
+++ b/crates/rust-mcp-server/src/workspace.rs
@@ -1,12 +1,31 @@
+use std::path::Path;
+
 use rmcp::service::NotificationContext;
 
-use crate::globals;
+use crate::globals::{self, WorkspaceRoot};
 
-/// Applies the workspace root to a command if it is set
-pub fn apply_workspace_root(cmd: &mut std::process::Command) {
-    if let Some(root) = globals::get_workspace_root() {
-        cmd.current_dir(root);
+/// Resolves the working directory a cargo command should run in, given the
+/// request's `--manifest-path` (if any). Priority:
+///
+/// 1. An explicitly configured workspace root (e.g. via the CLI) always wins.
+/// 2. Otherwise, the directory of the manifest, so cargo discovers that
+///    project's local `.cargo/config.toml`. Config discovery walks up from the
+///    working directory, not from the manifest path, so `--manifest-path` alone
+///    would silently ignore the project's own config.
+/// 3. Otherwise, an auto-detected workspace root.
+pub fn command_cwd(manifest_path: Option<&str>) -> Option<&Path> {
+    if let Some(root @ WorkspaceRoot::Explicit(_)) = globals::get_workspace_root() {
+        return Some(root.path());
     }
+
+    // Only absolute manifest paths select the manifest's directory: a relative
+    // one would no longer resolve once the working directory changes, and MCP
+    // clients pass absolute paths.
+    manifest_path
+        .map(Path::new)
+        .filter(|path| path.is_absolute())
+        .and_then(Path::parent)
+        .or_else(|| globals::get_workspace_root().map(WorkspaceRoot::path))
 }
 
 /// If CWD contains `Cargo.toml` then function does nothing. Otherwise it tries to detect workspace root from client roots.


### PR DESCRIPTION
this fix allows cargo to auto discover project's `.cargo/config.toml`

#140