### PR TITLE
fix: implement a workaround for rust-lang/rustfmt/issues/6934

### DIFF
--- a/crates/rust-mcp-server/src/response.rs
+++ b/crates/rust-mcp-server/src/response.rs
@@ -3,12 +3,21 @@ use rmcp::model::ContentBlock;
 use crate::command::{AgentRecommendation, Output};
 
 pub(crate) struct Response {
-    output: Output,
+    outputs: Vec<Output>,
     additional_content: Vec<ContentBlock>,
     recommendations: Vec<AgentRecommendation>,
 }
 
 impl Response {
+    pub(crate) fn from_outputs(outputs: Vec<Output>) -> Self {
+        debug_assert!(!outputs.is_empty());
+        Self {
+            outputs,
+            additional_content: Vec::new(),
+            recommendations: Vec::new(),
+        }
+    }
+
     pub(crate) fn add_content(&mut self, content: ContentBlock) {
         self.additional_content.push(content);
     }
@@ -22,7 +31,15 @@ impl Response {
         self,
         ignore_recommendations: bool,
     ) -> rmcp::model::CallToolResult {
-        let mut result: rmcp::model::CallToolResult = self.output.into();
+        let mut result = rmcp::model::CallToolResult::default();
+        result.is_error = Some(false);
+        for output in self.outputs {
+            let output: rmcp::model::CallToolResult = output.into();
+            result.content.extend(output.content);
+            if output.is_error == Some(true) {
+                result.is_error = Some(true);
+            }
+        }
         result.content.extend(self.additional_content);
         if !ignore_recommendations {
             result
@@ -35,11 +52,7 @@ impl Response {
 
 impl From<Output> for Response {
     fn from(val: Output) -> Self {
-        Response {
-            output: val,
-            additional_content: Vec::new(),
-            recommendations: Vec::new(),
-        }
+        Self::from_outputs(vec![val])
     }
 }
 
@@ -73,6 +86,31 @@ mod tests {
         );
         assert_eq!(stdout.as_text().unwrap().text, "This is a test output");
         assert_eq!(exit_status.as_text().unwrap().text, "✅ test_tool: Success");
+    }
+
+    #[test]
+    fn multiple_outputs_remain_distinct() {
+        let output = |command: &str| Output {
+            tool_name: "test_tool".into(),
+            stdout: None,
+            stderr: None,
+            cmd_line: CommandLine(command.into()),
+            exit_status: ExitStatus(std::process::ExitStatus::default()),
+        };
+
+        let result =
+            Response::from_outputs(vec![output("first"), output("second")]).into_rmcp_result(false);
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(result.content.len(), 4);
+        assert_eq!(
+            result.content[0].as_text().unwrap().text,
+            "Executed command: `first`"
+        );
+        assert_eq!(
+            result.content[2].as_text().unwrap().text,
+            "Executed command: `second`"
+        );
     }
 
     #[test]

--- a/crates/rust-mcp-server/src/tools/cargo/fmt.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/fmt.rs
@@ -3,9 +3,9 @@
 //! - rust-mcp-server#136: `cargo fmt --manifest-path` fails for virtual manifests unless
 //!   `--all` or an explicit package is selected. Add `--all` automatically when the caller
 //!   leaves `all` unset.
-//! - rust-lang/rustfmt#6934: large workspaces can exceed the OS command-line limit. Retry
-//!   eligible workspace or explicit-package requests one package at a time. Never apply this
-//!   retry to `--all`, because it also covers local path dependencies outside the workspace.
+//! - rust-lang/rustfmt#6934: large Windows workspaces can exceed the OS command-line limit.
+//!   Retry eligible workspace or explicit-package requests one package at a time. Never apply
+//!   this retry to `--all`, because it also covers local path dependencies outside the workspace.
 
 use std::{path::Path, process::Command};
 
@@ -55,7 +55,7 @@ pub struct CargoFmtRequest {
 
 impl CargoFmtRequest {
     pub fn build_cmd(&self) -> Result<Command, ErrorData> {
-        let mut cmd = self.base_cmd();
+        let mut cmd = self.base_cmd()?;
 
         if let Some(packages) = &self.package {
             for package in packages {
@@ -67,42 +67,23 @@ impl CargoFmtRequest {
             cmd.arg("--all");
         }
 
-        self.push_common_args(&mut cmd)?;
-
         Ok(cmd)
     }
 
     /// Builds a `cargo fmt` command scoped to a single package.
     fn build_package_cmd(&self, package: &str) -> Result<Command, ErrorData> {
-        let mut cmd = self.base_cmd();
+        let mut cmd = self.base_cmd()?;
         cmd.arg("--package").arg(package);
-        self.push_common_args(&mut cmd)?;
         Ok(cmd)
     }
 
-    /// `cargo [+toolchain] fmt` without any package or formatting options.
-    fn base_cmd(&self) -> Command {
+    /// `cargo [+toolchain] fmt` with formatting, manifest and output options.
+    fn base_cmd(&self) -> Result<Command, ErrorData> {
         let mut cmd = Command::new("cargo");
         if let Some(toolchain) = &self.toolchain {
             cmd.arg(format!("+{toolchain}"));
         }
         cmd.arg("fmt");
-        cmd
-    }
-
-    fn use_all(&self) -> bool {
-        self.all.unwrap_or_else(|| {
-            self.package.as_ref().is_none_or(Vec::is_empty)
-                && self
-                    .manifest_path
-                    .as_deref()
-                    .is_some_and(is_virtual_manifest)
-        })
-    }
-
-    /// Appends the formatting, manifest and output options shared by every
-    /// `cargo fmt` invocation.
-    fn push_common_args(&self, cmd: &mut Command) -> Result<(), ErrorData> {
         if self.check {
             cmd.arg("--check");
         }
@@ -115,18 +96,29 @@ impl CargoFmtRequest {
         cmd.args(output_verbosity_to_cli_flags(
             self.output_verbosity.as_deref(),
         )?);
-        Ok(())
+        Ok(cmd)
+    }
+
+    fn use_all(&self) -> bool {
+        self.all.unwrap_or_else(|| {
+            self.package.as_ref().is_none_or(Vec::is_empty)
+                && self
+                    .manifest_path
+                    .as_deref()
+                    .is_some_and(is_virtual_manifest)
+        })
     }
 }
 
-/// Returns `true` when `stderr` shows the rust-lang/rustfmt#6934 failure, where
-/// `cargo fmt` builds a command line longer than the OS allows ("os error 206"
-/// on Windows).
+#[cfg(not(windows))]
+fn cmd_line_too_long(_stderr: &str) -> bool {
+    false
+}
+
+/// Returns `true` when `stderr` shows the rust-lang/rustfmt#6934 failure.
+#[cfg(windows)]
 fn cmd_line_too_long(stderr: &str) -> bool {
-    stderr.contains("os error 206")
-        || stderr.contains("filename or extension is too long")
-        || stderr.contains("os error 7")
-        || stderr.contains("argument list too long")
+    stderr.contains("os error 206") || stderr.contains("filename or extension is too long")
 }
 
 fn is_virtual_manifest(manifest_path: &str) -> bool {
@@ -385,6 +377,7 @@ mod tests {
         ));
     }
 
+    #[cfg(windows)]
     #[test]
     fn detects_command_line_too_long() {
         // Windows surfaces rust-lang/rustfmt#6934 as os error 206.
@@ -392,11 +385,19 @@ mod tests {
             "error: The filename or extension is too long. (os error 206)"
         ));
         assert!(cmd_line_too_long("The filename or extension is too long."));
-        assert!(cmd_line_too_long(
-            "error: Argument list too long (os error 7)"
-        ));
         assert!(!cmd_line_too_long(
             "error[internal]: left behind trailing whitespace"
+        ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn ignores_command_line_too_long() {
+        assert!(!cmd_line_too_long(
+            "error: The filename or extension is too long. (os error 206)"
+        ));
+        assert!(!cmd_line_too_long(
+            "error: Argument list too long (os error 7)"
         ));
     }
 

--- a/crates/rust-mcp-server/src/tools/cargo/fmt.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/fmt.rs
@@ -1,0 +1,470 @@
+//! Cargo-fmt compatibility fixes:
+//!
+//! - rust-mcp-server#136: `cargo fmt --manifest-path` fails for virtual manifests unless
+//!   `--all` or an explicit package is selected. Add `--all` automatically when the caller
+//!   leaves `all` unset.
+//! - rust-lang/rustfmt#6934: large workspaces can exceed the OS command-line limit. Retry
+//!   eligible workspace or explicit-package requests one package at a time. Never apply this
+//!   retry to `--all`, because it also covers local path dependencies outside the workspace.
+
+use std::{path::Path, process::Command};
+
+use crate::{
+    Response, Tool, command_cwd, execute_command,
+    serde_utils::{deserialize_string, deserialize_string_vec, output_verbosity_to_cli_flags},
+};
+use rmcp::ErrorData;
+use serde::Deserialize;
+
+#[derive(Debug, ::serde::Deserialize, schemars::JsonSchema)]
+pub struct CargoFmtRequest {
+    /// The toolchain to use, e.g., "stable" or "nightly".
+    #[serde(default, deserialize_with = "deserialize_string")]
+    toolchain: Option<String>,
+
+    /// The name of the package(s) to format. If not specified, formats the current package.
+    #[serde(default, deserialize_with = "deserialize_string_vec")]
+    package: Option<Vec<String>>,
+
+    /// Format all packages, and also their local path-based dependencies.
+    /// When unset, `--all` is added automatically for virtual workspace manifests.
+    #[serde(default)]
+    all: Option<bool>,
+
+    /// Run rustfmt in check mode (don't write changes, just check if formatting is needed)
+    #[serde(default)]
+    check: bool,
+
+    /// Specify path to Cargo.toml
+    #[serde(default, deserialize_with = "deserialize_string")]
+    manifest_path: Option<String>,
+
+    /// Specify message-format: short|json|human
+    #[serde(default, deserialize_with = "deserialize_string")]
+    message_format: Option<String>,
+
+    /// Output verbosity level.
+    ///
+    /// Valid options:
+    /// - "quiet" (default): Show only the essential command output
+    /// - "normal": Show standard output (no additional flags)
+    /// - "verbose": Show detailed output including build information
+    #[serde(default, deserialize_with = "deserialize_string")]
+    output_verbosity: Option<String>,
+}
+
+impl CargoFmtRequest {
+    pub fn build_cmd(&self) -> Result<Command, ErrorData> {
+        let mut cmd = self.base_cmd();
+
+        if let Some(packages) = &self.package {
+            for package in packages {
+                cmd.arg("--package").arg(package);
+            }
+        }
+
+        if self.use_all() {
+            cmd.arg("--all");
+        }
+
+        self.push_common_args(&mut cmd)?;
+
+        Ok(cmd)
+    }
+
+    /// Builds a `cargo fmt` command scoped to a single package.
+    fn build_package_cmd(&self, package: &str) -> Result<Command, ErrorData> {
+        let mut cmd = self.base_cmd();
+        cmd.arg("--package").arg(package);
+        self.push_common_args(&mut cmd)?;
+        Ok(cmd)
+    }
+
+    /// `cargo [+toolchain] fmt` without any package or formatting options.
+    fn base_cmd(&self) -> Command {
+        let mut cmd = Command::new("cargo");
+        if let Some(toolchain) = &self.toolchain {
+            cmd.arg(format!("+{toolchain}"));
+        }
+        cmd.arg("fmt");
+        cmd
+    }
+
+    fn use_all(&self) -> bool {
+        self.all.unwrap_or_else(|| {
+            self.package.as_ref().is_none_or(Vec::is_empty)
+                && self
+                    .manifest_path
+                    .as_deref()
+                    .is_some_and(is_virtual_manifest)
+        })
+    }
+
+    /// Appends the formatting, manifest and output options shared by every
+    /// `cargo fmt` invocation.
+    fn push_common_args(&self, cmd: &mut Command) -> Result<(), ErrorData> {
+        if self.check {
+            cmd.arg("--check");
+        }
+        if let Some(manifest_path) = &self.manifest_path {
+            cmd.arg("--manifest-path").arg(manifest_path);
+        }
+        if let Some(message_format) = &self.message_format {
+            cmd.arg("--message-format").arg(message_format);
+        }
+        cmd.args(output_verbosity_to_cli_flags(
+            self.output_verbosity.as_deref(),
+        )?);
+        Ok(())
+    }
+}
+
+/// Returns `true` when `stderr` shows the rust-lang/rustfmt#6934 failure, where
+/// `cargo fmt` builds a command line longer than the OS allows ("os error 206"
+/// on Windows).
+fn cmd_line_too_long(stderr: &str) -> bool {
+    stderr.contains("os error 206")
+        || stderr.contains("filename or extension is too long")
+        || stderr.contains("os error 7")
+        || stderr.contains("argument list too long")
+}
+
+fn is_virtual_manifest(manifest_path: &str) -> bool {
+    let Ok(contents) = std::fs::read_to_string(manifest_path) else {
+        return false;
+    };
+    manifest_contents_are_virtual(&contents)
+}
+
+fn manifest_contents_are_virtual(contents: &str) -> bool {
+    let mut has_workspace = false;
+    let mut has_package = false;
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.starts_with("[workspace]") || line.starts_with("[workspace.") {
+            has_workspace = true;
+        } else if line.starts_with("[package]") || line.starts_with("[package.") {
+            has_package = true;
+        }
+    }
+    has_workspace && !has_package
+}
+
+#[derive(Deserialize)]
+struct CargoMetadata {
+    workspace_root: std::path::PathBuf,
+    packages: Vec<MetadataPackage>,
+}
+
+#[derive(Deserialize)]
+struct MetadataPackage {
+    name: String,
+    manifest_path: std::path::PathBuf,
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+fn packages_for_cwd(metadata: CargoMetadata, cwd: &Path) -> Vec<String> {
+    if same_path(&metadata.workspace_root, cwd) {
+        return metadata
+            .packages
+            .into_iter()
+            .map(|package| package.name)
+            .collect();
+    }
+
+    metadata
+        .packages
+        .into_iter()
+        .filter(|package| {
+            package
+                .manifest_path
+                .parent()
+                .is_some_and(|path| same_path(path, cwd))
+        })
+        .map(|package| package.name)
+        .collect()
+}
+
+pub struct CargoFmtRmcpTool;
+
+impl CargoFmtRmcpTool {
+    fn retry_packages(
+        request: &CargoFmtRequest,
+        cwd: Option<&Path>,
+    ) -> Result<Option<Vec<String>>, ErrorData> {
+        if request.use_all() {
+            return Ok(None);
+        }
+
+        if let Some(packages) = request
+            .package
+            .as_ref()
+            .filter(|packages| !packages.is_empty())
+        {
+            return Ok((packages.len() > 1).then(|| packages.clone()));
+        }
+
+        let mut cmd = Command::new("cargo");
+        if let Some(toolchain) = &request.toolchain {
+            cmd.arg(format!("+{toolchain}"));
+        }
+        cmd.args(["metadata", "--no-deps", "--format-version", "1"]);
+        if let Some(manifest_path) = &request.manifest_path {
+            cmd.arg("--manifest-path").arg(manifest_path);
+        }
+        if let Some(cwd) = cwd {
+            cmd.current_dir(cwd);
+        }
+
+        let output = cmd
+            .output()
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        if !output.status.success() {
+            tracing::warn!(
+                "Could not inspect workspace for cargo fmt retry: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Ok(None);
+        }
+
+        let metadata: CargoMetadata = match serde_json::from_slice(&output.stdout) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::warn!("Could not parse cargo metadata for cargo fmt retry: {error}");
+                return Ok(None);
+            }
+        };
+        let effective_cwd = cwd
+            .map(Path::to_path_buf)
+            .or_else(|| std::env::current_dir().ok());
+        let Some(effective_cwd) = effective_cwd else {
+            return Ok(None);
+        };
+        let packages = packages_for_cwd(metadata, &effective_cwd);
+        Ok((packages.len() > 1).then_some(packages))
+    }
+
+    fn format_per_package(
+        request: &CargoFmtRequest,
+        packages: &[String],
+        cwd: Option<&Path>,
+    ) -> Result<Response, ErrorData> {
+        tracing::warn!(
+            "cargo fmt hit rust-lang/rustfmt#6934; retrying {} packages individually",
+            packages.len()
+        );
+
+        let mut outputs = Vec::with_capacity(packages.len());
+        for package in packages {
+            let output = execute_command(
+                request.build_package_cmd(package)?,
+                CargoFmtRmcpTool::NAME,
+                cwd,
+            )?;
+            let failed = !output.success();
+            outputs.push(output);
+            if failed {
+                break;
+            }
+        }
+
+        let executed = outputs.len();
+        let failed = outputs.last().is_some_and(|output| !output.success());
+        let mut response = Response::from_outputs(outputs);
+        response.add_recommendation(format!(
+            "cargo fmt hit rust-lang/rustfmt#6934; retried {executed} of {} packages individually",
+            packages.len()
+        ));
+        if failed && request.check {
+            response.add_recommendation(format!(
+                "Run #{} with `check: false` to automatically format the code",
+                CargoFmtRmcpTool::NAME
+            ));
+        }
+        Ok(response)
+    }
+}
+
+impl Tool for CargoFmtRmcpTool {
+    const NAME: &'static str = "cargo-fmt";
+    const TITLE: &'static str = "Format Rust code";
+    const DESCRIPTION: &'static str =
+        "Formats Rust code using rustfmt. Usually, run without any additional arguments.";
+    type RequestArgs = CargoFmtRequest;
+
+    fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<Response, ErrorData> {
+        let cwd = command_cwd(request.manifest_path.as_deref());
+        let output = execute_command(request.build_cmd()?, Self::NAME, cwd)?;
+
+        // Work around rust-lang/rustfmt#6934 only when that specific failure hit.
+        if !output.success()
+            && output
+                .stderr
+                .as_ref()
+                .is_some_and(|e| cmd_line_too_long(&e.0))
+            && let Some(packages) = Self::retry_packages(&request, cwd)?
+        {
+            return Self::format_per_package(&request, &packages, cwd);
+        }
+
+        let failed = !output.success();
+        let mut response: Response = output.into();
+
+        if failed && request.check {
+            response.add_recommendation(format!(
+                "Run #{} with `check: false` to automatically format the code",
+                Self::NAME
+            ));
+        }
+
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn does_not_change_default_scope_for_manifest_path() {
+        let request: CargoFmtRequest = serde_json::from_value(serde_json::json!({
+            "manifest_path": "/workspace/Cargo.toml"
+        }))
+        .unwrap();
+        let cmd = request.build_cmd().unwrap();
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            ["fmt", "--manifest-path", "/workspace/Cargo.toml", "--quiet"]
+        );
+    }
+
+    #[test]
+    fn adds_all_for_virtual_manifest() {
+        let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("Cargo.toml");
+        let request: CargoFmtRequest = serde_json::from_value(serde_json::json!({
+            "manifest_path": manifest_path
+        }))
+        .unwrap();
+        let cmd = request.build_cmd().unwrap();
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(args.iter().any(|arg| arg == "--all"));
+        assert_eq!(
+            CargoFmtRmcpTool::retry_packages(&request, None).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_virtual_manifest_contents() {
+        assert!(manifest_contents_are_virtual(
+            "[workspace]\nmembers = [\"crates/*\"]\n"
+        ));
+        assert!(manifest_contents_are_virtual("[workspace.package]\n"));
+        assert!(!manifest_contents_are_virtual(
+            "[package]\nname = \"foo\"\n"
+        ));
+        assert!(!manifest_contents_are_virtual(
+            "[workspace]\n\n[package.metadata]\nkey = \"value\"\n"
+        ));
+    }
+
+    #[test]
+    fn detects_command_line_too_long() {
+        // Windows surfaces rust-lang/rustfmt#6934 as os error 206.
+        assert!(cmd_line_too_long(
+            "error: The filename or extension is too long. (os error 206)"
+        ));
+        assert!(cmd_line_too_long("The filename or extension is too long."));
+        assert!(cmd_line_too_long(
+            "error: Argument list too long (os error 7)"
+        ));
+        assert!(!cmd_line_too_long(
+            "error[internal]: left behind trailing whitespace"
+        ));
+    }
+
+    #[test]
+    fn selects_all_packages_at_workspace_root() {
+        let metadata = CargoMetadata {
+            workspace_root: "/workspace".into(),
+            packages: vec![
+                MetadataPackage {
+                    name: "first".into(),
+                    manifest_path: "/workspace/first/Cargo.toml".into(),
+                },
+                MetadataPackage {
+                    name: "second".into(),
+                    manifest_path: "/workspace/second/Cargo.toml".into(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            packages_for_cwd(metadata, Path::new("/workspace")),
+            ["first", "second"]
+        );
+    }
+
+    #[test]
+    fn selects_only_current_workspace_member() {
+        let metadata = CargoMetadata {
+            workspace_root: "/workspace".into(),
+            packages: vec![
+                MetadataPackage {
+                    name: "first".into(),
+                    manifest_path: "/workspace/first/Cargo.toml".into(),
+                },
+                MetadataPackage {
+                    name: "second".into(),
+                    manifest_path: "/workspace/second/Cargo.toml".into(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            packages_for_cwd(metadata, Path::new("/workspace/first")),
+            ["first"]
+        );
+    }
+
+    #[test]
+    fn retries_explicit_packages_without_discovery() {
+        let request: CargoFmtRequest = serde_json::from_value(serde_json::json!({
+            "package": ["first", "second"]
+        }))
+        .unwrap();
+
+        assert_eq!(
+            CargoFmtRmcpTool::retry_packages(&request, None).unwrap(),
+            Some(vec!["first".into(), "second".into()])
+        );
+    }
+
+    #[test]
+    fn does_not_narrow_all_to_workspace_packages() {
+        let request: CargoFmtRequest =
+            serde_json::from_value(serde_json::json!({ "all": true })).unwrap();
+
+        assert_eq!(
+            CargoFmtRmcpTool::retry_packages(&request, None).unwrap(),
+            None
+        );
+    }
+}

--- a/crates/rust-mcp-server/src/tools/cargo/fmt.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/fmt.rs
@@ -214,9 +214,13 @@ impl CargoFmtRmcpTool {
             cmd.current_dir(cwd);
         }
 
-        let output = cmd
-            .output()
-            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let output = match cmd.output() {
+            Ok(output) => output,
+            Err(error) => {
+                tracing::warn!("Could not run cargo metadata for cargo fmt retry: {error}");
+                return Ok(None);
+            }
+        };
         if !output.status.success() {
             tracing::warn!(
                 "Could not inspect workspace for cargo fmt retry: {}",

--- a/crates/rust-mcp-server/src/tools/cargo/mod.rs
+++ b/crates/rust-mcp-server/src/tools/cargo/mod.rs
@@ -3,6 +3,7 @@ mod build;
 mod check;
 mod clippy;
 mod doc;
+mod fmt;
 mod info;
 mod metadata;
 mod package;
@@ -17,6 +18,7 @@ pub use build::CargoBuildRmcpTool;
 pub use check::CargoCheckRmcpTool;
 pub use clippy::CargoClippyRmcpTool;
 pub use doc::CargoDocRmcpTool;
+pub use fmt::CargoFmtRmcpTool;
 pub use info::CargoInfoRmcpTool;
 pub use metadata::CargoMetadataRmcpTool;
 pub use package::CargoPackageRmcpTool;
@@ -255,159 +257,6 @@ impl Tool for CargoCleanRmcpTool {
 }
 
 #[derive(Debug, ::serde::Deserialize, schemars::JsonSchema)]
-pub struct CargoFmtRequest {
-    /// The toolchain to use, e.g., "stable" or "nightly".
-    #[serde(default, deserialize_with = "deserialize_string")]
-    toolchain: Option<String>,
-
-    /// The name of the package(s) to format. If not specified, formats the current package.
-    #[serde(default, deserialize_with = "deserialize_string_vec")]
-    package: Option<Vec<String>>,
-
-    /// Format all packages, and also their local path-based dependencies.
-    /// When unset, `--all` is added automatically for virtual workspace manifests.
-    #[serde(default)]
-    all: Option<bool>,
-
-    /// Run rustfmt in check mode (don't write changes, just check if formatting is needed)
-    #[serde(default)]
-    check: bool,
-
-    /// Specify path to Cargo.toml
-    #[serde(default, deserialize_with = "deserialize_string")]
-    manifest_path: Option<String>,
-
-    /// Specify message-format: short|json|human
-    #[serde(default, deserialize_with = "deserialize_string")]
-    message_format: Option<String>,
-
-    /// Output verbosity level.
-    ///
-    /// Valid options:
-    /// - "quiet" (default): Show only the essential command output
-    /// - "normal": Show standard output (no additional flags)
-    /// - "verbose": Show detailed output including build information
-    #[serde(default, deserialize_with = "deserialize_string")]
-    output_verbosity: Option<String>,
-}
-
-impl CargoFmtRequest {
-    pub fn build_cmd(&self) -> Result<Command, ErrorData> {
-        let mut cmd = Command::new("cargo");
-        if let Some(toolchain) = &self.toolchain {
-            cmd.arg(format!("+{toolchain}"));
-        }
-        cmd.arg("fmt");
-
-        // Package selection
-        if let Some(packages) = &self.package {
-            for package in packages {
-                cmd.arg("--package").arg(package);
-            }
-        }
-
-        // `cargo fmt` fails with "Failed to find targets" when pointed at a
-        // virtual workspace manifest (a `[workspace]` root without a
-        // `[package]`) unless `--all` or an explicit `--package` is provided.
-        // When `all` is unset, detect that case and add `--all` automatically.
-        let use_all = self.all.unwrap_or_else(|| {
-            let no_package = self.package.as_ref().is_none_or(|p| p.is_empty());
-            let auto = no_package
-                && self
-                    .manifest_path
-                    .as_deref()
-                    .is_some_and(is_virtual_manifest);
-            if auto {
-                tracing::info!(
-                    "Detected virtual workspace manifest; adding --all to cargo fmt automatically"
-                );
-            }
-            auto
-        });
-
-        if use_all {
-            cmd.arg("--all");
-        }
-
-        // Formatting options
-        if self.check {
-            cmd.arg("--check");
-        }
-
-        // Manifest options
-        if let Some(manifest_path) = &self.manifest_path {
-            cmd.arg("--manifest-path").arg(manifest_path);
-        }
-
-        if let Some(message_format) = &self.message_format {
-            cmd.arg("--message-format").arg(message_format);
-        }
-
-        // Output options
-        let output_flags = output_verbosity_to_cli_flags(self.output_verbosity.as_deref())?;
-        cmd.args(output_flags);
-
-        Ok(cmd)
-    }
-}
-
-/// Returns `true` if the given `Cargo.toml` is a virtual manifest, i.e. a
-/// workspace root that contains a `[workspace]` table but no `[package]`.
-///
-/// Returns `false` when the file cannot be read, so callers fall back to
-/// cargo's default behavior.
-fn is_virtual_manifest(manifest_path: &str) -> bool {
-    let Ok(contents) = std::fs::read_to_string(manifest_path) else {
-        return false;
-    };
-    manifest_contents_are_virtual(&contents)
-}
-
-/// Returns `true` if the manifest contents describe a virtual manifest, i.e.
-/// they contain a `[workspace]` table but no `[package]` table (matching
-/// cargo's definition of a virtual manifest). Sub-tables such as
-/// `[workspace.package]` and `[package.metadata]` are recognized as well.
-fn manifest_contents_are_virtual(contents: &str) -> bool {
-    let mut has_workspace = false;
-    let mut has_package = false;
-    for line in contents.lines() {
-        let line = line.trim();
-        if line.starts_with("[workspace]") || line.starts_with("[workspace.") {
-            has_workspace = true;
-        } else if line.starts_with("[package]") || line.starts_with("[package.") {
-            has_package = true;
-        }
-    }
-    has_workspace && !has_package
-}
-
-pub struct CargoFmtRmcpTool;
-
-impl Tool for CargoFmtRmcpTool {
-    const NAME: &'static str = "cargo-fmt";
-    const TITLE: &'static str = "Format Rust code";
-    const DESCRIPTION: &'static str =
-        "Formats Rust code using rustfmt. Usually, run without any additional arguments.";
-    type RequestArgs = CargoFmtRequest;
-
-    fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
-        let cwd = command_cwd(request.manifest_path.as_deref());
-        let output = execute_command(request.build_cmd()?, Self::NAME, cwd)?;
-        let failed = !output.success();
-        let mut response: crate::Response = output.into();
-
-        if failed && request.check {
-            response.add_recommendation(format!(
-                "Run #{} with `check: false` to automatically format the code",
-                Self::NAME
-            ));
-        }
-
-        Ok(response)
-    }
-}
-
-#[derive(Debug, ::serde::Deserialize, schemars::JsonSchema)]
 pub struct CargoNewRequest {
     /// The toolchain to use, e.g., "stable" or "nightly".
     #[serde(default, deserialize_with = "deserialize_string")]
@@ -543,31 +392,5 @@ impl Tool for CargoListRmcpTool {
 
     fn call_rmcp_tool(&self, request: Self::RequestArgs) -> Result<crate::Response, ErrorData> {
         execute_command(request.build_cmd()?, Self::NAME, command_cwd(None)).map(Into::into)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn virtual_manifest_detection() {
-        assert!(manifest_contents_are_virtual(
-            "[workspace]\nmembers = [\"crates/*\"]\n"
-        ));
-        assert!(manifest_contents_are_virtual("[workspace.package]\n"));
-        assert!(!manifest_contents_are_virtual(
-            "[package]\nname = \"foo\"\n"
-        ));
-        assert!(!manifest_contents_are_virtual(
-            "  [package]  # inline comment\nname = \"foo\"\n"
-        ));
-        assert!(!manifest_contents_are_virtual(
-            "[workspace]\n\n[package.metadata]\nkey = \"value\"\n"
-        ));
-        // Neither `[package]` nor `[workspace]`: not a virtual manifest.
-        assert!(!manifest_contents_are_virtual(
-            "[dependencies]\nfoo = \"1\"\n"
-        ));
     }
 }


### PR DESCRIPTION
addresses https://github.com/rust-lang/rustfmt/issues/6934.
if `cargo-fmt` hits `The filename or extension is too long. (os error 206)` on windows, it will try to format project package by package